### PR TITLE
Fix batched_soft_nms torch.compile compatibility and bump versions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt update && sudo apt-get install -y wget unzip cmake libgtest-dev clang-format
       - name: Fetch libtorch
-        run: wget https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.9.1%2Bcpu.zip && unzip libtorch-shared-with-deps-2.9.1+cpu.zip
+        run: wget https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-2.12.0%2Bcpu.zip && unzip libtorch-shared-with-deps-2.12.0+cpu.zip
       - name: Run format checking
         run: bash scripts/run_format.sh -c
       - name: Run tests
@@ -34,7 +34,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
     - name: Install pytorch
       run: |
-        python -m pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu
+        python -m pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cpu
     - name: Run linting
       run: |
         bash scripts/ci_checks.sh
@@ -52,7 +52,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
     - name: Install pytorch
       run: |
-        python -m pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu
+        python -m pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cpu
     - name: Code coverage
       run: |
         python -m pip install --no-build-isolation -e .
@@ -68,7 +68,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
-        pytorch-version: ['2.9.1']
+        pytorch-version: ['2.12.0']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -102,7 +102,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
     - name: Install pytorch
       run: |
-        python -m pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu
+        python -m pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cpu
     - name: Install package
       run: |
         python -m pip install --no-build-isolation .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
       - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: 25.11.0
+    rev: 26.5.1
     hooks:
       - id: black
         args: [--line-length=128]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 7.0.0
+    rev: 8.0.1
     hooks:
       - id: isort
 

--- a/pt_soft_nms/soft_nms.py
+++ b/pt_soft_nms/soft_nms.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Tuple
 
 import torch
 
@@ -63,11 +63,10 @@ def batched_soft_nms(
     assert len(boxes.shape) == 2 and boxes.shape[-1] == 4, f"boxes has wrong shape, expected (N, 4), got {boxes.shape}"
     assert len(scores.shape) == 1, f"scores has wrong shape, expected (N,) got {scores.shape}"
 
-    result_mask = scores.new_zeros(scores.size(), dtype=torch.bool)
-    for id in torch.jit.annotate(List[int], torch.unique(idxs).cpu().tolist()):  # type: ignore
-        mask = torch.nonzero(idxs == id).view(-1)
-        _, keep = soft_nms(boxes[mask], scores[mask], sigma, score_threshold)
-        result_mask[mask[keep]] = True
-    keep = torch.nonzero(result_mask).view(-1)
-    keep = keep[scores[keep].argsort(descending=True)]
+    # Shift each class into a non-overlapping region of space so a single
+    # soft_nms call treats classes independently (IoU between classes = 0).
+    max_coordinate = boxes.max()
+    offsets = idxs.to(boxes) * (max_coordinate + 1)
+    boxes_for_nms = boxes + offsets[:, None]
+    _, keep = soft_nms(boxes_for_nms, scores, sigma, score_threshold)
     return keep

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-black==25.11.0
+black==26.5.1
 flake8==7.3.0
-isort==7.0.0
-mypy==1.18.2
-pre-commit==4.5.0
-pytest==9.0.1
-pytest-cov==7.0.0
-wheel==0.45.1
+isort==8.0.1
+mypy==2.1.0
+pre-commit==4.6.0
+pytest==9.0.3
+pytest-cov==7.1.0
+wheel==0.47.0

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -38,9 +38,8 @@ class TestCompileBatchedSoftNMS(unittest.TestCase):
         self.sigma = 0.5
         self.threshold = 0.1
 
-    @unittest.skip("TODO: fix compile for batched_soft_nms")
     def test_compile_cpu(self):
-        compiled_soft_nms = torch.compile(batched_soft_nms)
+        compiled_soft_nms = torch.compile(batched_soft_nms, fullgraph=True)
         _ = compiled_soft_nms(self.boxes, self.scores, self.idxs, self.sigma, self.threshold)
 
     @unittest.skip("TODO: fix compile for batched_soft_nms")


### PR DESCRIPTION
Replace data-dependent per-class loop in batched_soft_nms with the offset trick (same approach as torchvision), enabling fullgraph=True compilation. Also upgrade torch to 2.12.0 in CI and bump dev dependencies to their latest versions.