### PR TITLE
Migrate from black/isort/flake8 to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,10 @@
 repos:
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.14
     hooks:
-      - id: flake8
-
-  - repo: https://github.com/psf/black
-    rev: 26.5.1
-    hooks:
-      - id: black
-        args: [--line-length=128]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
 
   - repo: local
     hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,6 @@
-black==26.5.1
-flake8==7.3.0
-isort==8.0.1
 mypy==2.1.0
 pre-commit==4.6.0
 pytest==9.0.3
 pytest-cov==7.1.0
+ruff==0.15.14
 wheel==0.47.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+line-length = 128
+exclude = [".venv"]
+
+[lint]
+select = ["E", "W", "F", "I"]
+
+[lint.isort]
+force-sort-within-sections = false

--- a/scripts/ci_checks.sh
+++ b/scripts/ci_checks.sh
@@ -2,14 +2,11 @@
 
 set -e
 
-echo 'running flake8'
-flake8 .
+echo 'running ruff lint'
+ruff check .
 
-echo 'running isort'
-isort . --check
-
-echo 'running black'
-black . --check --line-length=128
+echo 'running ruff format'
+ruff format . --check
 
 echo 'running mypy'
 mypy .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,3 @@
-[flake8]
-max-line-length = 128
-exclude=.venv
-
-[isort]
-line_length = 128
-profile = black
-
 [mypy]
 ignore_missing_imports = true
 strict = true


### PR DESCRIPTION
Replace three separate tools with ruff for linting, import sorting, and formatting. Preserves existing settings (line-length=128, flake8 E/W/F rules).